### PR TITLE
appveyor.yml: Don't build a commit if the message contains [CI skip]

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: '{build}'
 image: Visual Studio 2019
+skip_commits:
+- message: /\[CI skip\]/
 install:
 - cinst llvm
 build_script:


### PR DESCRIPTION
To bypass CI builds when code isn't updated, [CI skip] can be used to
suppress it.