### PR TITLE
appveyor: Enforce clang-format usage on code.

### DIFF
--- a/ClientApps/DeveloperTools/DeveloperTools.cpp
+++ b/ClientApps/DeveloperTools/DeveloperTools.cpp
@@ -12,7 +12,7 @@ static DWORD __stdcall threadWrapper(LPVOID l) {
 }
 
 DeveloperTools::DeveloperTools() {
-	DWORD (*threadFunc)
+	DWORD(*threadFunc)
 	(LPVOID) = [](LPVOID) {
 		self.console.Run();
 		return 0ul;

--- a/ClientApps/TestLuaHookNG/CatchMain.cpp
+++ b/ClientApps/TestLuaHookNG/CatchMain.cpp
@@ -2,7 +2,6 @@
 #define CATCH_CONFIG_RUNNER
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
-
 #include <shellapi.h>
 
 #include <catch.hpp>
@@ -47,7 +46,7 @@ void TestLuaHookNG::CatchMain() {
 	  static_cast<wchar_t**>(CommandLineToArgvW(cmdLine, &argc)),
 	  localFree};
 	session.applyCommandLine(argc, argv.get());
-	DWORD (*threadWorker)
+	DWORD(*threadWorker)
 	(void*) = [](void* arg) -> DWORD {
 		return session.run();
 	};

--- a/LuaHook-NG/src/LuaHookNG.cpp
+++ b/LuaHook-NG/src/LuaHookNG.cpp
@@ -1,4 +1,5 @@
 #include "LuaHookNG.h"
+
 #include "Version.h"
 
 void LuaHookNG::LuaHook_NG() {}

--- a/LuaHook-NG/src/windows/DetoursCodeHook.cpp
+++ b/LuaHook-NG/src/windows/DetoursCodeHook.cpp
@@ -29,7 +29,7 @@ static std::string_view FindModuleBase() {
 class HookableFunc : public IHookable {
 	void* addr;
 
-   public:
+public:
 	HookableFunc(void* addr) : addr{addr} {}
 	void* Address() const noexcept override {
 		return addr;
@@ -37,12 +37,12 @@ class HookableFunc : public IHookable {
 };
 
 class HookedFunc : public IHooked {
-   protected:
+protected:
 	void* targetAddr;
 	void* detourAddr;
 	PDETOUR_TRAMPOLINE trampoline;
 
-   public:
+public:
 	HookedFunc(void* targetAddr,
 			   void* detourAddr,
 			   PDETOUR_TRAMPOLINE trampoline) :
@@ -62,7 +62,7 @@ class HookedFunc : public IHooked {
 };
 
 class SingleHook : public HookedFunc {
-   public:
+public:
 	SingleHook(void* tAddr, void* dtAddr) : HookedFunc{tAddr, dtAddr, nullptr} {
 		if (DetourTransactionBegin() != NO_ERROR)
 			throw std::runtime_error{
@@ -93,7 +93,7 @@ class SingleHook : public HookedFunc {
 class HookSet : public IHookSet {
 	std::vector<HookedFunc> hooks;
 
-   public:
+public:
 	HookSet(VecOfHooks&& toHook) {
 		hooks.reserve(toHook.size());
 		if (DetourTransactionBegin() != NO_ERROR)

--- a/LuaHook-NG/src/windows/x86/PAYDAY2/OnNewStateHandler.cpp
+++ b/LuaHook-NG/src/windows/x86/PAYDAY2/OnNewStateHandler.cpp
@@ -16,10 +16,10 @@ using namespace LuaHookNG;
 using namespace std::literals;
 
 static void __fastcall LuaHookNG::OnNewState(lua_State** L,
-								  void* edx,
-								  void* a,
-								  void* b,
-								  void* c);
+											 void* edx,
+											 void* a,
+											 void* b,
+											 void* c);
 
 static std::unique_ptr<IHooked> hook;
 static std::unique_ptr<IHookable> luaSetField;
@@ -77,10 +77,10 @@ void OnNewStateHandler::Init(IRuntimeCodeHook& cHook) {
 }
 
 void __fastcall LuaHookNG::OnNewState(lua_State** L,
-						   void* edx,
-						   void* a,
-						   void* b,
-						   void* c) {
+									  void* edx,
+									  void* a,
+									  void* b,
+									  void* c) {
 	{
 		auto setFieldHook =
 		  codeHook->Hook(luaSetField,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,12 @@ install:
 - cinst llvm
 build_script:
 - ps: >-
+    Get-ChildItem . -Recurse -Exclude out,.vs | where {$_.FullName -notmatch "out\\"} | where {$_.FullName -notmatch ".vs\\"} | where {$_.extension -eq ".cpp" -or $_.extension -eq ".h"} | ForEach-Object -Process { clang-format -style=file -i $_.FullName }
+
+    git diff --quiet
+
+    if (-not $?) { throw "Build failure. You have not applied Clang format to all of the source code." }
+
     $RELEASE_VER="0.0.1"
 
     if ($env:APPVEYOR_REPO_TAG -eq "true") { $RELEASE_VER = $env:APPVEYOR_REPO_TAG_NAME.Substring(1) }


### PR DESCRIPTION
The validation of code will now fail if it has not been formatted with
the in-repo .clang-format file.